### PR TITLE
Increase the .container max-width

### DIFF
--- a/static/css/main.css
+++ b/static/css/main.css
@@ -1785,7 +1785,7 @@ body.compensate-for-scrollbar {
 
 .container {
 	margin: 0 auto;
-	max-width: 770px;
+	max-width: 1024px;
 	padding: 0 15px;
 }
 
@@ -2873,7 +2873,7 @@ textarea {
 	}
 
 	.intro-section .partners-list {
-		max-width: 80%;
+		max-width: 75%;
 	}
 }
 
@@ -2900,6 +2900,10 @@ textarea {
 
 	.testimonials-slider .img-holder {
 		min-height: 450px;
+	}
+
+	.intro-section .partners-list {
+		max-width: 60%;
 	}
 }
 
@@ -2982,4 +2986,4 @@ textarea {
 		transform: rotate(359deg);
 	}
 }
-
+

--- a/static/index.html
+++ b/static/index.html
@@ -7,7 +7,7 @@
 	<title>	Talio</title>
 	<link rel="stylesheet" href="https://use.typekit.net/jzv2mme.css">
 	<link media="all" rel="stylesheet" href="css/main.css">
-	<script src="http://ajax.googleapis.com/ajax/libs/jquery/3.3.1/jquery.min.js" defer></script>
+	<script src="https://ajax.googleapis.com/ajax/libs/jquery/3.3.1/jquery.min.js" defer></script>
 	<script>window.jQuery || document.write('<script src="js/jquery-3.3.1.min.js" defer><\/script>')</script>
 	<script src="js/jquery.main.js" defer></script>
 </head>


### PR DESCRIPTION
The `.container` `max-width` is now 1024. I also modified some of the `width` percentages of `.partners-list` to better distribute the labels as the viewport is resized.